### PR TITLE
Integrate Oulu realtime data to OTP

### DIFF
--- a/roles/otp-docker-image/templates/router-config.json.j2
+++ b/roles/otp-docker-image/templates/router-config.json.j2
@@ -58,6 +58,22 @@
       "defaultAgencyId": "HSL",
       "fuzzyTripMatching": true,
       "alwaysIncremental": true
+    },
+    {
+      "type": "stop-time-updater",
+      "frequencySec": 60,
+      "sourceType": "gtfs-http",
+      "url": "http://92.62.36.215:8080/gtfs-rt/trip-updates",
+      "defaultAgencyId": "7317",
+      "fuzzyTripMatching": true,
+      "alwaysIncremental": true
+    },
+    {
+      "type": "real-time-alerts",
+      "frequencySec": 30,
+      "url": "http://92.62.36.215:8080/gtfs-rt/service-alerts",
+      "defaultAgencyId": "7317",
+      "fuzzyTripMatching": true
     }
   ],
   boardTimes: {

--- a/roles/otp-docker-image/templates/router-config.json.j2
+++ b/roles/otp-docker-image/templates/router-config.json.j2
@@ -63,7 +63,7 @@
       "type": "stop-time-updater",
       "frequencySec": 60,
       "sourceType": "gtfs-http",
-      "url": "http://92.62.36.215:8080/gtfs-rt/trip-updates",
+      "url": "{{oulu_gtfsrt_url}}/trip-updates",
       "defaultAgencyId": "7317",
       "fuzzyTripMatching": true,
       "alwaysIncremental": true
@@ -71,7 +71,7 @@
     {
       "type": "real-time-alerts",
       "frequencySec": 30,
-      "url": "http://92.62.36.215:8080/gtfs-rt/service-alerts",
+      "url": "{{oulu_gtfsrt_url}}/service-alerts",
       "defaultAgencyId": "7317",
       "fuzzyTripMatching": true
     }

--- a/variables/common.yaml
+++ b/variables/common.yaml
@@ -52,6 +52,8 @@ hsl_alert_docker_image: "{{docker_image_base}}/hsl-alert"
 hsl_alert_exposed_port: 8085
 hsl_alert_git: https://github.com/HSLdevcom/hslalert
 
+oulu_gtfsrt_url: "http://92.62.36.215:8080/gtfs-rt"
+
 siri2gtfsrt_root: "{{docker_build_root}}/siri2gtfsrt"
 siri2gtfsrt_docker_image: "{{docker_image_base}}/siri2gtfsrt"
 siri2gtfsrt_exposed_port: 8086


### PR DESCRIPTION
Stop time updater worked when tested locally. Real-time alerts have so far returned only empty feeds.
